### PR TITLE
Fix a call to get-text-property

### DIFF
--- a/calfw.el
+++ b/calfw.el
@@ -1141,7 +1141,7 @@ faces, the faces are remained."
       (let ((str (truncate-string-to-width
                   (substring org 0) limit-width 0 nil ellipsis)))
         (cfw:tp str 'mouse-face 'highlight)
-        (unless (get-text-property str 'help-echo str)
+        (unless (get-text-property 0 'help-echo str)
           (cfw:tp str 'help-echo org))
         str)
     org))


### PR DESCRIPTION
Hi Masashi,

there was an error in a call to get-text-property for getting props of an org agenda item where the string itself was given as POSITION arg.  I've fixed it in my fork, so feel free to pull.

BTW: I've seen that you've added an extra keymap for org with SPC bound to cfw:org-open-agenda-day.  Do I need to configure something to make that work?  In the calendar buffer, SPC is still bound to cfw:show-details-command.  When I execute cfw:org-open-agenda-day using M-x, I get the org agenda for that day, but the command is not bound to any key.
