### PR TITLE
Pull request for Calfw-org.el

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -142,6 +142,35 @@ If TEXT does not have a range, return nil."
            (list (calendar-gregorian-from-absolute d1) 
                  (calendar-gregorian-from-absolute d2) text)))))
 
+(defun cfw:org-get-timerange2 (text)
+  "Return a range object (begin end text).
+If TEXT does not have a range, return nil."
+  (let* ((dotime (cfw:org-tp text 'txt))
+         (ps (and dotime (stringp dotime) (string-match org-tr-regexp dotime))))
+    (and ps
+         (let* ((s1 (match-string 1 dotime))
+                (s2 (match-string 2 dotime))
+                (d1 (time-to-days (org-time-string-to-time s1)))
+                (d2 (time-to-days (org-time-string-to-time s2))))
+           (list (calendar-gregorian-from-absolute d1) 
+                 (calendar-gregorian-from-absolute d2) text)))))
+
+(defun cfw:org-get-timerange3 (text)
+  "Return a range object (begin end text).
+If TEXT does not have a range, return nil."
+  (let (extra date begin end)
+    (setq extra (cfw:org-tp text 'extra))
+    (setq date (cfw:org-tp text 'date))
+    (if (and extra (string-match "(\\([1-9]*\\)\/\\([1-9]*\\)): " extra))
+	(progn
+	  (setq begin (string-to-number (match-string 1 extra)))
+	  (setq end (string-to-number (match-string 2 extra)))
+	  (setq today (calendar-absolute-from-gregorian date))
+	  (list 
+	   (calendar-gregorian-from-absolute  (- today (- begin 1)))
+	   (calendar-gregorian-from-absolute (+ today (- end begin)))
+	   text)))))
+
 (defun cfw:org-schedule-period-to-calendar (begin end)
   "[internal] Return calfw calendar items between BEGIN and END
 from the org schedule data."


### PR DESCRIPTION
An entry which has period info(example:\* <2011-8-1 Mon>--<2011-8-2 Tue> Going back to home town) is displayed as a long string likes "<2011-08-01 Mon>--<2011-08-02 Tue> back to home town".
I think it is too long for a limited space on calendar buffer. 
I can only see "<2011-08-01 Mon>--<2011-08-02..." on calendar buffer.
So, I modified function cfw:org-extract-summary to remove a part which matchs org-tr-regexp from org-item.
