### PR TITLE
Use (eq major-mode 'org-mode) instead of org-mode-p.

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -62,7 +62,7 @@
       (switch-to-buffer (marker-buffer marker))
       (widen)
       (goto-char (marker-position marker))
-      (when (org-mode-p)
+      (when (eq major-mode 'org-mode)
         (org-reveal)))))
 
 


### PR DESCRIPTION
This is only a minor change, but upstream org-mode erased the function org-mode-p which was exactly (eq major-mode 'org-mode) anyway.
