### PR TITLE
Faster navigation, fix interactive numeric arguments, allow customization of go-to-date

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -217,6 +217,11 @@ TEXT1 < TEXT2. This function makes no-time items in front of timed-items."
     ;; exec org-remember here?
     ))
 
+(defun cfw:org-read-date-command ()
+  "Move the cursor to the specified date."
+  (interactive)
+  (cfw:emacs-to-calendar (org-read-date nil 'to-time)))
+
 ;; (progn (eval-current-buffer) (cfw:open-org-calendar))
 ;; (setq org-agenda-files '("./org-samples/complex.org"))
 

--- a/calfw.el
+++ b/calfw.el
@@ -110,6 +110,12 @@
   :group 'cfw
   :type 'character)
 
+(defcustom cfw:read-date-command 'cfw:read-date-command-simple
+  "The command used to read the date in `cfw:navi-goto-date-command',
+for example `cfw:read-date-command-simple' or `cfw:org-read-date-command'."
+  :group 'cfw
+  :type 'function)
+
 ;;; Faces
 
 (defface cfw:face-title
@@ -346,6 +352,11 @@ ones of DATE2. Otherwise is `nil'."
 (defun cfw:parsetime (str)
   "Transform the string format YYYY/MM/DD to a calendar date value."
   (cfw:emacs-to-calendar (cfw:parsetime-emacs str)))
+
+(defun cfw:read-date-command-simple (string-date)
+  "Move the cursor to the specified date."
+  (interactive "sInput Date (YYYY/MM/DD): ")
+  (cfw:parsetime string-date))
 
 (defun cfw:enumerate-days (begin end)
   "Enumerate date objects between BEGIN and END."
@@ -2288,10 +2299,10 @@ With prefix arg NO-RESIZE, don't fit calendar to window size."
      (cfw:week-end-date
       (cfw:cp-get-selected-date (cfw:cp-get-component))))))
 
-(defun cfw:navi-goto-date-command (string-date)
+(defun cfw:navi-goto-date-command ()
   "Move the cursor to the specified date."
-  (interactive "sInput Date (YYYY/MM/DD): ")
-  (cfw:navi-goto-date (cfw:parsetime string-date)))
+  (interactive)
+  (cfw:navi-goto-date (call-interactively cfw:read-date-command)))
 
 (defun cfw:navi-goto-today-command ()
   "Move the cursor to today."


### PR DESCRIPTION
Hi,

I made the navigation functions accept numeric prefixes and bound "0" through "9" to `digit-argument', so that you can simply type "7 n" to jump forward by seven weeks.

Also I replaced "<return>" in calfw-org with "RET", so that the return key and control-m have the same effect.

The last part allows for customization of the function prompting for the date in `cfw:navi-goto-date-command': The original (default) read-"YYYY/MM/DD" and one using`org-read-date' are available.
