### PR TITLE
Fixed parentheses problem in cfw:open-ical-calendar (cp not inside let)

### DIFF
--- a/calfw-ical.el
+++ b/calfw-ical.el
@@ -276,8 +276,8 @@ calendar source."
     (let ((cp (cfw:create-calendar-component-buffer
                :view 'month
                :contents-sources
-               (list (cfw:ical-create-source "ical" url "#2952a3"))))))
-    (switch-to-buffer (cfw:cp-get-buffer cp))))
+               (list (cfw:ical-create-source "ical" url "#2952a3")))))
+      (switch-to-buffer (cfw:cp-get-buffer cp)))))
 
 ;; (progn (eval-current-buffer) (cfw:open-ical-calendar "./ics/test.ics"))
 


### PR DESCRIPTION
I just found a small problem in `cfw:open-ical-calendar`. One of the closed parentheses needed to be moved. Otherwise, `cp` is not defined when it is referenced.