### PR TITLE
FIX: Events from org-mode lasting for more than one day are shown correctly in blocks (#11)

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -221,7 +221,7 @@ If this function splits into a list of string, the calfw displays those string i
   "Return a range object (begin end text).
 If TEXT does not have a range, return nil."
   (let* ((dotime (cfw:org-tp text 'dotime)))
-    (and dotime	(string-match org-ts-regexp dotime)
+    (and (stringp dotime) (string-match org-ts-regexp dotime)
 	 (let ((date-string  (match-string 1 dotime))
 	       (extra (cfw:org-tp text 'extra)))
 	   (if (string-match "(\\([0-9]+\\)/\\([0-9]+\\)): " extra)

--- a/calfw-org.el
+++ b/calfw-org.el
@@ -225,18 +225,18 @@ If TEXT does not have a range, return nil."
 	 (let ((date-string  (match-string 1 dotime))
 	       (extra (cfw:org-tp text 'extra)))
 	   (if (string-match "(\\([0-9]+\\)/\\([0-9]+\\)): " extra)
-	       (let* ((cur_day (string-to-int
+	       (let* ((cur-day (string-to-int
 				(match-string 1 extra)))
-		      (total_days (string-to-int
+		      (total-days (string-to-int
 				   (match-string 2 extra)))
-		      (start_date (time-subtract
+		      (start-date (time-subtract
 				   (org-read-date nil t date-string)
-				   (seconds-to-time (* 3600 24 (- cur_day 1)))))
-		      (end_date (time-add
+				   (seconds-to-time (* 3600 24 (- cur-day 1)))))
+		      (end-date (time-add
 				 (org-read-date nil t date-string)
-				 (seconds-to-time (* 3600 24 (- total_days cur_day))))))
-		 (list (calendar-gregorian-from-absolute (time-to-days start_date))
-		       (calendar-gregorian-from-absolute (time-to-days end_date)) text))
+				 (seconds-to-time (* 3600 24 (- total-days cur-day))))))
+		 (list (calendar-gregorian-from-absolute (time-to-days start-date))
+		       (calendar-gregorian-from-absolute (time-to-days end-date)) text))
 	     )))))
 
 (defun cfw:org-schedule-period-to-calendar (begin end)

--- a/calfw-org.el
+++ b/calfw-org.el
@@ -220,15 +220,24 @@ If this function splits into a list of string, the calfw displays those string i
 (defun cfw:org-get-timerange (text)
   "Return a range object (begin end text).
 If TEXT does not have a range, return nil."
-  (let* ((dotime (cfw:org-tp text 'dotime))
-         (ps (and dotime (stringp dotime) (string-match org-tr-regexp dotime))))
-    (and ps
-         (let* ((s1 (match-string 1 dotime))
-                (s2 (match-string 2 dotime))
-                (d1 (time-to-days (org-time-string-to-time s1)))
-                (d2 (time-to-days (org-time-string-to-time s2))))
-           (list (calendar-gregorian-from-absolute d1)
-                 (calendar-gregorian-from-absolute d2) text)))))
+  (let* ((dotime (cfw:org-tp text 'dotime)))
+    (and dotime	(string-match org-ts-regexp dotime)
+	 (let ((date-string  (match-string 1 dotime))
+	       (extra (cfw:org-tp text 'extra)))
+	   (if (string-match "(\\([0-9]+\\)/\\([0-9]+\\)): " extra)
+	       (let* ((cur_day (string-to-int
+				(match-string 1 extra)))
+		      (total_days (string-to-int
+				   (match-string 2 extra)))
+		      (start_date (time-subtract
+				   (org-read-date nil t date-string)
+				   (seconds-to-time (* 3600 24 (- cur_day 1)))))
+		      (end_date (time-add
+				 (org-read-date nil t date-string)
+				 (seconds-to-time (* 3600 24 (- total_days cur_day))))))
+		 (list (calendar-gregorian-from-absolute (time-to-days start_date))
+		       (calendar-gregorian-from-absolute (time-to-days end_date)) text))
+	     )))))
 
 (defun cfw:org-schedule-period-to-calendar (begin end)
   "[internal] Return calfw calendar items between BEGIN and END
@@ -244,9 +253,11 @@ from the org schedule data."
    (unless (member range periods)
      (push range periods))
    else do
-   (setq contents (cfw:contents-add
-                   (cfw:org-normalize-date date)
-                   line contents))
+   ; dotime is not present if this event was already added as a timerange
+   (if (cfw:org-tp i 'dotime)
+       (setq contents (cfw:contents-add
+		       (cfw:org-normalize-date date)
+		       line contents)))
    finally return (nconc contents (list (cons 'periods periods)))))
 
 (defun cfw:org-schedule-sorter (text1 text2)


### PR DESCRIPTION
Hello,
this pull request fixes the issue of calfw not recognizing events lasting for several days as reported in issue #11. The problem arose because org mode apparently changed its behaviour with the "dotime" property of the event. In order to fix this issue, I check if an event has the "extra" property set with a value of something like eg. "(1/3): ". This "extra" property give the information of which day you are in in a multi day event, here its day one of three. You can see this extra property in action when you look at a multi day event in the Agenda view.

Anyhow, I am rather new to elisp so comments and suggestions are very welcome! This fix works well for me and I hope some other people will find it useful too!