### PR TITLE
Deadline with NUM is displayed from NUM days before the date.

### DIFF
--- a/calfw-howm.el
+++ b/calfw-howm.el
@@ -72,7 +72,7 @@ to the number of howm encoded days."
   "[internal] Return howm schedule items between BEGIN and END."
   (let* ((from (cfw:to-howm-date begin))
          (to (cfw:to-howm-date end))
-         (filtered (howm-cl-remove-if
+         (filtered (cl-remove-if
                     (lambda (item)
                       (let ((s (howm-schedule-date item)))
                         (or (< s from)

--- a/calfw-howm.el
+++ b/calfw-howm.el
@@ -104,8 +104,10 @@ from the howm schedule data."
         for summary = (funcall cfw:howm-schedule-summary-transformer summary)
         do
         (cond
-         ((< 0 num)
+         ((and (string= type "@") (< 0 num))
           (push (list date (cfw:date-after date (1- num)) summary) periods))
+         ((and (string= type "!") (< 0 num))
+          (push (list (cfw:date-before date (1- num)) date summary) periods))
          (t
           (setq contents (cfw:contents-add date summary contents))))
         finally return (nconc contents (list (cons 'periods periods)))))

--- a/calfw.el
+++ b/calfw.el
@@ -440,6 +440,11 @@ ones of DATE2. Otherwise is `nil'."
   (calendar-gregorian-from-absolute
    (+ (calendar-absolute-from-gregorian date) num)))
 
+(defun cfw:date-before (date num)
+  "Return the date before NUM days from DATE."
+  (calendar-gregorian-from-absolute
+   (- (calendar-absolute-from-gregorian date) num)))
+
 (defun cfw:strtime-emacs (time)
   "Format emacs time value TIME to the string form YYYY/MM/DD."
   (format-time-string "%Y/%m/%d" time))


### PR DESCRIPTION
This PR contains 2 commits:

Since current Howm in melpa does not have 'howm-cl-remove-if', we should use 'cl-remove-if'.

A deadline item followed by NUM should be displayed on the calendar from NUM days before the deadline date.  For example, [2017-06-20]!3 should be displayed as a period 2017/06/18 - 2017/06/20 instead of 2017/06/20 - 2017/06/22.
