### PR TITLE
org-create-file-source RECURING EVENT fix

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -92,8 +92,8 @@ For example,
   (let ((org-agenda-prefix-format " ")
         (span 'day))
     (setq org-agenda-buffer
-      (when (buffer-live-p org-agenda-buffer)
-        org-agenda-buffer))
+	  (when (buffer-live-p org-agenda-buffer)
+            org-agenda-buffer))
     (org-compile-prefix-format nil)
     (cl-loop for date in (cfw:enumerate-days begin end) append
              (cl-loop for file in (or cfw:org-icalendars (org-agenda-files nil 'ifmode))
@@ -108,11 +108,11 @@ For example,
   "Jump to the clicked org item."
   (interactive)
   (let (
-    (marker (get-text-property (point) 'org-marker))
-    (link   (get-text-property (point) 'org-link))
-    (file   (get-text-property (point) 'cfw:org-file))
-    (beg    (get-text-property (point) 'cfw:org-h-beg))
-    (loc    (get-text-property (point) 'cfw:org-loc)))
+	(marker (get-text-property (point) 'org-marker))
+	(link   (get-text-property (point) 'org-link))
+	(file   (get-text-property (point) 'cfw:org-file))
+	(beg    (get-text-property (point) 'cfw:org-h-beg))
+	(loc    (get-text-property (point) 'cfw:org-loc)))
     (when link
       (org-open-link-from-string link))
     (when (and marker (marker-buffer marker))
@@ -156,8 +156,8 @@ For example,
     ;; (when (string-match cfw:org-todo-keywords-regexp item) ; dynamic bind
     ;;   (setq item (replace-match "" nil nil item)))
     (if tags
-      (when (string-match (concat "[\t ]*:+" (mapconcat 'identity tags ":+") ":+[\t ]*$") item)
-        (setq item (replace-match "" nil nil item))))
+	(when (string-match (concat "[\t ]*:+" (mapconcat 'identity tags ":+") ":+[\t ]*$") item)
+          (setq item (replace-match "" nil nil item))))
     (when (string-match "[0-9]\\{2\\}:[0-9]\\{2\\}\\(-[0-9]\\{2\\}:[0-9]\\{2\\}\\)?[\t ]+" item)
       (setq item (replace-match "" nil nil item)))
     (when (string-match "^ +" item)
@@ -183,27 +183,27 @@ For example,
     (when (string-match (concat "^" org-deadline-string ".*") extra)
       (add-text-properties 0 (length text) (list 'face (org-agenda-deadline-face 1.0)) text))
     (if org-todo-keywords-for-agenda
-      (when (string-match (concat "^[\t ]*\\<\\(" (mapconcat 'identity org-todo-keywords-for-agenda "\\|") "\\)\\>") text)
-        (add-text-properties (match-beginning 1) (match-end 1) (list 'face (org-get-todo-face (match-string 1 text))) text)))
+	(when (string-match (concat "^[\t ]*\\<\\(" (mapconcat 'identity org-todo-keywords-for-agenda "\\|") "\\)\\>") text)
+          (add-text-properties (match-beginning 1) (match-end 1) (list 'face (org-get-todo-face (match-string 1 text))) text)))
     ;;; ------------------------------------------------------------------------
     ;;; act for org link
     ;;; ------------------------------------------------------------------------
     (setq text (replace-regexp-in-string "%[0-9A-F]\\{2\\}" " " text))
     (if (string-match org-bracket-link-regexp text)
-      (let* ((desc (if (match-end 3) (org-match-string-no-properties 3 text)))
-             (link (org-link-unescape (org-match-string-no-properties 1 text)))
-             (help (concat "LINK: " link))
-             (link-props (list
-                          'face 'org-link
-                          'mouse-face 'highlight
-                          'help-echo help
-                          'org-link link)))
-        (if desc
-            (progn
-              (setq desc (apply 'propertize desc link-props))
-              (setq text (replace-match desc nil nil text)))
-          (setq link (apply 'propertize link link-props))
-          (setq text (replace-match link nil nil text)))))
+	(let* ((desc (if (match-end 3) (org-match-string-no-properties 3 text)))
+               (link (org-link-unescape (org-match-string-no-properties 1 text)))
+               (help (concat "LINK: " link))
+               (link-props (list
+                            'face 'org-link
+                            'mouse-face 'highlight
+                            'help-echo help
+                            'org-link link)))
+          (if desc
+              (progn
+		(setq desc (apply 'propertize desc link-props))
+		(setq text (replace-match desc nil nil text)))
+            (setq link (apply 'propertize link link-props))
+            (setq text (replace-match link nil nil text)))))
     (when time-str
       (setq text (concat time-str text)))
     (propertize
@@ -262,7 +262,7 @@ from the org schedule data."
    (unless (member range periods)
      (push range periods))
    else do
-   ; dotime is not present if this event was already added as a timerange
+					; dotime is not present if this event was already added as a timerange
    (if (cfw:org-tp i 'dotime)
        (setq contents (cfw:contents-add
 		       (cfw:org-normalize-date date)
@@ -297,17 +297,17 @@ TEXT1 < TEXT2. This function makes no-time items in front of timed-items."
 
 (defun cfw:org-format-title (file h-obj t-obj h-beg loc)
   (propertize
-  (concat
-   (when  (org-element-property :hour-start t-obj)
-     (format "%02i:%02i "
-             (org-element-property :hour-start t-obj)
-             (org-element-property :minute-start t-obj)))
-   (org-element-property :title h-obj))
-  'keymap cfw:org-text-keymap
-  'display nil
-  'cfw:org-file file
-  'cfw:org-h-beg h-beg
-  'cfw:org-loc loc))
+   (concat
+    (when  (org-element-property :hour-start t-obj)
+      (format "%02i:%02i "
+              (org-element-property :hour-start t-obj)
+              (org-element-property :minute-start t-obj)))
+    (org-element-property :title h-obj))
+   'keymap cfw:org-text-keymap
+   'display nil
+   'cfw:org-file file
+   'cfw:org-h-beg h-beg
+   'cfw:org-loc loc))
 
 (defun cfw:org-format-date (t-obj lst)
   (mapcar
@@ -349,7 +349,7 @@ TEXT1 < TEXT2. This function makes no-time items in front of timed-items."
                            (lambda (hl) (org-element-property :begin hl) ))
                        ,@(org-element-map (org-element-map elem-obj 'headline
                                             (lambda (hl)
-                                 (org-element-property :deadline hl) ) ) 'timestamp
+					      (org-element-property :deadline hl) ) ) 'timestamp
                            (lambda (hl) (org-element-property :begin hl) ))
                        ,@(org-element-map (org-element-map elem-obj 'headline
                                             (lambda (hl)
@@ -410,8 +410,8 @@ TEXT1 < TEXT2. This function makes no-time items in front of timed-items."
               ">"))))
 
 (when cfw:org-capture-template
-(setq org-capture-templates
-      (append org-capture-templates (list cfw:org-capture-template))))
+  (setq org-capture-templates
+	(append org-capture-templates (list cfw:org-capture-template))))
 
 (defun cfw:org-capture ()
   "Open org-agenda buffer on the selected date."

--- a/calfw-org.el
+++ b/calfw-org.el
@@ -113,13 +113,12 @@ For example,
             org-agenda-buffer))
     (org-compile-prefix-format nil)
     (cl-loop for date in (cfw:enumerate-days begin end) append
-             (cl-loop for file in (list file)
-                      append
-                      (progn
-			(org-check-agenda-file file)
-			(apply 'org-agenda-get-day-entries
-                               file date
-                               cfw:org-agenda-schedule-args))))))
+	     (let ((file file))
+               (progn
+		 (org-check-agenda-file file)
+		 (apply 'org-agenda-get-day-entries
+                        file date
+                        cfw:org-agenda-schedule-args))))))
 
 (defun cfw:org-onclick ()
   "Jump to the clicked org item."


### PR DESCRIPTION
Fix recurring events in single-org-file sources

Prior to this change, recurring events worked
in org-create-source, but NOT in org-create-file-source.
This is not the cleanest lisp code, because I am
cookbooking my way through making something work
and not properly understanding what I am doing,
BUT org-create-file-source NOW handles recurring
events correctly.

Ideally, instead of making separate sets of functions for
cfw:org-file-schedule-period-to-calendar and
cfw:org-file-collect-schedules-period
I should have made the "file" argument ":optional"
(in both original functions) and handled both
org-create-file-source and org-create-source
through the same chain of
cfw:org-schedule-period-to-calendar and
cfw:org-file-collect-schedules-period
... My lisp skills were not up to completing
that approach CLEANLY, so I have done things this way.