### PR TITLE
Fix: calfw-org: Ensure that string-match does not get nil input

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -180,7 +180,7 @@ For example,
          (props (cfw:extract-text-props item 'face 'keymap))
          (extra (cfw:org-tp item 'extra)))
     (setq text (substring-no-properties text))
-    (when (string-match (concat "^" org-deadline-string ".*") extra)
+    (when (and extra (string-match (concat "^" org-deadline-string ".*") extra))
       (add-text-properties 0 (length text) (list 'face (org-agenda-deadline-face 1.0)) text))
     (if org-todo-keywords-for-agenda
       (when (string-match (concat "^[\t ]*\\<\\(" (mapconcat 'identity org-todo-keywords-for-agenda "\\|") "\\)\\>") text)
@@ -230,10 +230,10 @@ If this function splits into a list of string, the calfw displays those string i
   "Return a range object (begin end text).
 If TEXT does not have a range, return nil."
   (let* ((dotime (cfw:org-tp text 'dotime)))
-    (and (stringp dotime) (string-match org-ts-regexp dotime)
+    (and (stringp dotime) (and dotime (string-match org-ts-regexp dotime))
 	 (let ((date-string  (match-string 1 dotime))
 	       (extra (cfw:org-tp text 'extra)))
-	   (if (string-match "(\\([0-9]+\\)/\\([0-9]+\\)): " extra)
+	   (if (and extra (string-match "(\\([0-9]+\\)/\\([0-9]+\\)): " extra))
 	       (let* ((cur-day (string-to-number
 				(match-string 1 extra)))
 		      (total-days (string-to-number


### PR DESCRIPTION
With the following customization:

```elisp
    (setq cfw:org-agenda-schedule-args
          '(:deadline :scheduled :timestamp))
```

`M-x cfw:open-org-calendar` fails to render. This happens because the functions `cfw:org-summary-format` and `cfw:org-get-timerange` do not guard against text properties being nil when calling `string-match`.

This commit adds the guard, which leads to the calendar rendering correctly.