### PR TITLE
Fix duplicate display of org time ranges

### DIFF
--- a/calfw-org.el
+++ b/calfw-org.el
@@ -286,14 +286,21 @@ day in the calendar."
                      text)))))))
 
 (defun calfw-org--range-dates-exist-p (range periods)
-  "Check if a range with the same start and end dates exists in PERIODS.
-Compares only the date components, ignoring the text, to prevent
-duplicate display when org-agenda returns two entries for a single
-time range (one for start time, one for end time)."
-  (cl-some (lambda (existing)
-             (and (equal (car range) (car existing))
-                  (equal (cadr range) (cadr existing))))
-           periods))
+  "Check if a range with the same dates and summary exists in PERIODS.
+Compares start date, end date, and the summary text with any
+leading time prefix stripped, to prevent false deduplication of
+genuinely different events that share the same date range."
+  (let ((range-summary (replace-regexp-in-string
+                        "^[0-9]\\{2\\}:[0-9]\\{2\\} " ""
+                        (substring-no-properties (caddr range)))))
+    (cl-some (lambda (existing)
+               (and (equal (car range) (car existing))
+                    (equal (cadr range) (cadr existing))
+                    (equal range-summary
+                           (replace-regexp-in-string
+                            "^[0-9]\\{2\\}:[0-9]\\{2\\} " ""
+                            (substring-no-properties (caddr existing))))))
+             periods)))
 
 (defun calfw-org--schedule-period-to-calendar (org-files begin end)
   "Return calfw calendar items between BEGIN and END from ORG-FILES."

--- a/calfw-org.el
+++ b/calfw-org.el
@@ -285,6 +285,16 @@ day in the calendar."
                       (time-to-days end-date))
                      text)))))))
 
+(defun calfw-org--range-dates-exist-p (range periods)
+  "Check if a range with the same start and end dates exists in PERIODS.
+Compares only the date components, ignoring the text, to prevent
+duplicate display when org-agenda returns two entries for a single
+time range (one for start time, one for end time)."
+  (cl-some (lambda (existing)
+             (and (equal (car range) (car existing))
+                  (equal (cadr range) (cadr existing))))
+           periods))
+
 (defun calfw-org--schedule-period-to-calendar (org-files begin end)
   "Return calfw calendar items between BEGIN and END from ORG-FILES."
   (cl-loop
@@ -296,7 +306,7 @@ day in the calendar."
    for range = (calfw-org-get-timerange line (and (equal date begin) date))
    if range
    do
-   (unless (member range periods)
+   (unless (calfw-org--range-dates-exist-p range periods)
      (push range periods))
    else do
    ;; dotime is not present if this event was already added as a timerange


### PR DESCRIPTION
# Fix duplicate display of org time ranges in calendar

## Problem

When a SCHEDULED (or DEADLINE) entry uses a time range:

```org
** TODO Trip Rotterdam
SCHEDULED: <2026-05-20 Wed 19:05>--<2026-05-28 Thu 23:30>
```

the event is displayed **twice** in the calfw calendar — once with the start time and once with the end time.

## Cause

`org-agenda-get-day-entries` returns two separate entries for a single time range, one per timestamp. Both are detected as ranges by `calfw-org-get-timerange`, producing two tuples:

```
(start-date end-date "19:05 Trip Rotterdam")
(start-date end-date "23:30 Trip Rotterdam")
```

The existing deduplication check `(member range periods)` uses `equal`, which compares the full tuple including the text component. Since the text differs (different time strings), both entries pass the check and get displayed.

## Fix

Replace the `member` check with a new function `calfw-org--range-dates-exist-p` that compares ranges by start date, end date, and the event summary with the leading time prefix (`HH:MM `) stripped.

This correctly deduplicates two entries from the same range (which only differ in their time prefix) while preserving genuinely different events that happen to share the same date span:

```org
** TODO Trip Rotterdam
SCHEDULED: <2026-05-20 Wed 19:05>--<2026-05-28 Thu 23:30>

** TODO Conference Rotterdam
SCHEDULED: <2026-05-20 Wed 09:00>--<2026-05-28 Thu 17:00>
```

Both events are kept; only the duplicate within each event is suppressed.

This is a minimal, backward-compatible change — single-timestamp events are unaffected.
